### PR TITLE
Filter HTML content / markup correctly in courier emails

### DIFF
--- a/src/Entity/Email.php
+++ b/src/Entity/Email.php
@@ -155,7 +155,7 @@ class Email extends ChannelBase implements EmailInterface {
       $params = [
         'context' => [
           'subject' => $message->getSubject(),
-          'message' => $message->getBody(),
+          'message' => check_markup($message->getBody(), $message->getBodyFormat(), $message->language()->getId()),
         ],
       ];
 


### PR DESCRIPTION
HTML has to be processed by check_markup in the set body format to correctly display HTML in E-Mails. Otherwise HTML is always escaped in emails and the message is not being handled / filtered by the selected text format.